### PR TITLE
Removed quotes around attributes

### DIFF
--- a/awsssocredrestore/__init__.py
+++ b/awsssocredrestore/__init__.py
@@ -41,7 +41,7 @@ def retrieve_attribute(profile, tag):
 def set_attribute(config, profile_name, tag, value):
     """ Safely find and set the desired attribute from the AWS profile credentials. """
     # Set Values in file in defined section
-    config.set(profile_name, tag, "\"%s\"" % value)
+    config.set(profile_name, tag, "%s" % value)
 
 
 def retrieve_all_profiles():


### PR DESCRIPTION
The current implementation writes all attributes surrounded by quotes:

``` text
[c-free-ops]
aws_access_key_id = "xxxx"
aws_secret_access_key = "yyyy"
aws_session_token = "zzzz"
```

That seems to work ok with Terraform (I think that uses the go sdk), but it doesn't work with the NodeJS SDK.

This PR doesn't removes the double quotes, so that creds look like this:

``` text
[c-free-ops]
aws_access_key_id = xxxx
aws_secret_access_key = yyyy
aws_session_token = zzzz
```

That's also consistent with the way `aws configure` works