### PR TITLE
Remove quotes while updating credentials file

### DIFF
--- a/awsssocredrestore/__init__.py
+++ b/awsssocredrestore/__init__.py
@@ -41,7 +41,7 @@ def retrieve_attribute(profile, tag):
 def set_attribute(config, profile_name, tag, value):
     """ Safely find and set the desired attribute from the AWS profile credentials. """
     # Set Values in file in defined section
-    config.set(profile_name, tag, "\"%s\"" % value)
+    config.set(profile_name, tag, "%s" % value)
 
 
 def retrieve_all_profiles():


### PR DESCRIPTION
The `aws_access_key_id, aws_secret_access_key,` were being created with a quotation mark into the `~/.aws/credential` file. This worked ok for Terraform but made the AWS CLI to fail.