### PR TITLE
Force output to JSON for `aws sso get-role-credentials` output

### DIFF
--- a/awsssocredrestore/__init__.py
+++ b/awsssocredrestore/__init__.py
@@ -129,7 +129,8 @@ def get_role_credentials(profile_name, sso_role_name, sso_account_id, sso_access
             "--role-name", sso_role_name,
             "--account-id", sso_account_id,
             "--access-token", sso_access_token,
-            "--region", sso_region
+            "--region", sso_region,
+            "--output", "json"
         ],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE


### PR DESCRIPTION
otherwise it relies on other settings and can lead to mysterious failures, ie when output is set to `text`